### PR TITLE
LIBFCREPO-1068. Modified Solr faceting to support "([College Park])"

### DIFF
--- a/fedora4/core/conf/schema.xml
+++ b/fedora4/core/conf/schema.xml
@@ -175,7 +175,7 @@
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <charFilter
             class="solr.PatternReplaceCharFilterFactory"
-            pattern="\ \(College\ Park.*"
+            pattern="\ \(\[?College\ Park.*"
             replacement="" />
     </analyzer>
   </fieldType>


### PR DESCRIPTION
Modified the "issue_title_custom_text" Solr field to support stripping
both "(College Park" and "([College Park" (with subsequent text).

This change is to support the "La voz latina" newspaper.

https://issues.umd.edu/browse/LIBFCREPO-1068