### PR TITLE
LIBFCREPO-1151. Added "handle" field to schema.

### DIFF
--- a/fedora4/core/conf/index-helper.js
+++ b/fedora4/core/conf/index-helper.js
@@ -63,6 +63,7 @@ var PCDM_FILES_FIELD = "pcdm_files";
 var ANNOTATION_SOURCE_FIELD = "annotation_source";
 var ANNOTATION_TARGET_FIELD = "annotation_target";
 var GENRE_FIELD = "genre";
+var HANDLE_FIELD = "handle";
 
 // SOLR FIELDS
 var SOLR_OBJECT_TYPE = "object_type";
@@ -100,6 +101,7 @@ function processAdd(cmd) {
     setExtractedTextSource(doc);
   }
   removeURIGenreValues(doc);
+  removeHDLPrefix(doc);
 
   logger.debug("update-script#processAdd: updated keys=" + doc.keySet());
 }
@@ -359,5 +361,13 @@ function removeURIGenreValues(doc) {
     if (!(genre[i].startsWith('http://') || genre[i].startsWith('https://'))) {
       doc.addField(GENRE_FIELD, genre[i]);
     }
+  }
+}
+
+// remove the "hdl:" URI prefix from the handle field value
+function removeHDLPrefix(doc) {
+  if (hasValue(doc, HANDLE_FIELD)) {
+    var handle = doc.getFieldValue(HANDLE_FIELD);
+    doc.setField(HANDLE_FIELD, handle.replace(/^hdl:/, ""));
   }
 }

--- a/fedora4/core/conf/schema.xml
+++ b/fedora4/core/conf/schema.xml
@@ -45,6 +45,7 @@
   <field name="recipient_with_uri" type="uri_tagged_text" indexed="true" stored="true" multiValued="true"/>
   <field name="author_with_uri" type="uri_tagged_text" indexed="true" stored="true" multiValued="true"/>
   <field name="identifier" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="handle" type="string" indexed="true" stored="true" multiValued="false"/>
 
   <!-- Multilingual fields -->
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+from uuid import uuid4
+
+import pytest
+from pysolr import Solr
+
+
+@pytest.fixture()
+def solr_endpoint():
+    return os.environ.get('SOLR_ENDPOINT', 'http://localhost:8983/solr/fedora4')
+
+
+@pytest.fixture()
+def solr(solr_endpoint):
+    return Solr(solr_endpoint)
+
+
+@pytest.fixture
+def index(solr):
+    """
+    Fixture factory for creating Solr documents, and then cleaning them up
+    after the test is complete.
+    """
+
+    uuids = []
+
+    def _index(fields):
+        uuid = str(uuid4())
+        uuids.append(uuid)
+        solr.add([{'id': uuid, **fields}])
+        solr.commit()
+        return solr.search(f'id:{uuid}').docs[0]
+
+    yield _index
+
+    # clean up after ourselves
+    solr.delete(id=uuids)
+    solr.commit()

--- a/tests/test_date_field.py
+++ b/tests/test_date_field.py
@@ -1,32 +1,4 @@
-import os
-from uuid import uuid4
-
 import pytest
-from pysolr import Solr
-
-
-def _index_doc(solr, doc):
-    uuid = str(uuid4())
-    solr.add([{'id': uuid, **doc}])
-    solr.commit()
-    results = solr.search(f'id:{uuid}')
-    return uuid, results
-
-
-def _cleanup(solr, uuid):
-    # clean up after ourselves
-    solr.delete(id=uuid)
-    solr.commit()
-
-
-@pytest.fixture()
-def solr_endpoint():
-    return os.environ.get('SOLR_ENDPOINT', 'http://localhost:8983/solr/fedora4')
-
-
-@pytest.fixture()
-def solr(solr_endpoint):
-    return Solr(solr_endpoint)
 
 
 @pytest.mark.parametrize(
@@ -44,10 +16,9 @@ def solr(solr_endpoint):
         ('2XXX', '2000-01-01T00:00:00Z'),
     ]
 )
-def test_date_field_year_only(solr, input_date, output_date):
-    uuid, results = _index_doc(solr, {'date': input_date})
-    assert results.docs[0]['date'] == output_date
-    _cleanup(solr, uuid)
+def test_date_field_year_only(index, input_date, output_date):
+    doc = index({'date': input_date})
+    assert doc['date'] == output_date
 
 
 @pytest.mark.parametrize(
@@ -76,10 +47,9 @@ def test_date_field_year_only(solr, input_date, output_date):
         ('2XXX-1X', '2000-10-01T00:00:00Z'),
     ]
 )
-def test_date_field_year_month(solr, input_date, output_date):
-    uuid, results = _index_doc(solr, {'date': input_date})
-    assert results.docs[0]['date'] == output_date
-    _cleanup(solr, uuid)
+def test_date_field_year_month(index, input_date, output_date):
+    doc = index({'date': input_date})
+    assert doc['date'] == output_date
 
 
 @pytest.mark.parametrize(
@@ -154,10 +124,9 @@ def test_date_field_year_month(solr, input_date, output_date):
         ('2XXX-1X-3X', '2000-10-30T00:00:00Z'),
     ]
 )
-def test_date_field_year_month_day(solr, input_date, output_date):
-    uuid, results = _index_doc(solr, {'date': input_date})
-    assert results.docs[0]['date'] == output_date
-    _cleanup(solr, uuid)
+def test_date_field_year_month_day(index, input_date, output_date):
+    doc = index({'date': input_date})
+    assert doc['date'] == output_date
 
 
 @pytest.mark.parametrize(
@@ -169,10 +138,9 @@ def test_date_field_year_month_day(solr, input_date, output_date):
         ('../2012', '2012-01-01T00:00:00Z'),
     ]
 )
-def test_date_field_interval(solr, input_date, output_date):
-    uuid, results = _index_doc(solr, {'date': input_date})
-    assert results.docs[0]['date'] == output_date
-    _cleanup(solr, uuid)
+def test_date_field_interval(index, input_date, output_date):
+    doc = index({'date': input_date})
+    assert doc['date'] == output_date
 
 
 @pytest.mark.parametrize(
@@ -183,10 +151,9 @@ def test_date_field_interval(solr, input_date, output_date):
         ('[..2012]', '2012-01-01T00:00:00Z'),
     ]
 )
-def test_date_field_set(solr, input_date, output_date):
-    uuid, results = _index_doc(solr, {'date': input_date})
-    assert results.docs[0]['date'] == output_date
-    _cleanup(solr, uuid)
+def test_date_field_set(index, input_date, output_date):
+    doc = index({'date': input_date})
+    assert doc['date'] == output_date
 
 
 @pytest.mark.parametrize(
@@ -202,7 +169,6 @@ def test_date_field_set(solr, input_date, output_date):
         ('2012-24', '2012-12-01T00:00:00Z'),
     ]
 )
-def test_date_field_seasons(solr, input_date, output_date):
-    uuid, results = _index_doc(solr, {'date': input_date})
-    assert results.docs[0]['date'] == output_date
-    _cleanup(solr, uuid)
+def test_date_field_seasons(index, input_date, output_date):
+    doc = index({'date': input_date})
+    assert doc['date'] == output_date

--- a/tests/test_handle_field.py
+++ b/tests/test_handle_field.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ('input_handle', 'output_handle'),
+    [
+        ('hdl:1903.1/12345', '1903.1/12345'),
+        # no prefix should be a no-op
+        ('1903.1/12345', '1903.1/12345'),
+        # empty string should be a no-op
+        ('', ''),
+        # non-hdl prefix should be a no-op
+        ('urn:isbn:1234566789', 'urn:isbn:1234566789'),
+        # only remove "hdl:" at the beginning
+        ('hdl:1903.1/hdl:bar', '1903.1/hdl:bar'),
+    ]
+)
+def test_remove_hdl_prefix(index, input_handle, output_handle):
+    doc = index({'handle': input_handle})
+    assert doc['handle'] == output_handle


### PR DESCRIPTION
- Field is a string, single-valued, indexed, and stored
- The index helper strips the leading "hdl:" before storing the value
- Added tests
- Converted the _index_doc and _cleanup functions into a single fixture factory named "index"
- The index fixture returns the indexed document instead of the search results
- Moved the test fixtures into a common conftest.py file so all tests have access to them

https://issues.umd.edu/browse/LIBFCREPO-1151