### PR TITLE
LIBFCREPO-1254. Add Solr fields for publication and discovery.

### DIFF
--- a/fedora4/core/conf/schema.xml
+++ b/fedora4/core/conf/schema.xml
@@ -46,6 +46,10 @@
   <field name="author_with_uri" type="uri_tagged_text" indexed="true" stored="true" multiValued="true"/>
   <field name="identifier" type="string" indexed="true" stored="true" multiValued="true"/>
   <field name="handle" type="string" indexed="true" stored="true" multiValued="false"/>
+  <field name="is_published" type="boolean" indexed="true" stored="true" multiValued="false"/>
+  <field name="is_hidden" type="boolean" indexed="true" stored="true" multiValued="false"/>
+  <field name="is_top_level" type="boolean" indexed="true" stored="true" multiValued="false"/>
+  <field name="is_discoverable" type="boolean" indexed="true" stored="true" multiValued="false"/>
 
   <!-- Multilingual fields -->
 

--- a/tests/test_publish_and_discovery.py
+++ b/tests/test_publish_and_discovery.py
@@ -1,0 +1,25 @@
+import pytest
+
+published_type = 'http://vocab.lib.umd.edu/access#Published'
+top_level_type = 'http://vocab.lib.umd.edu/model#Item'
+hidden_type = 'http://vocab.lib.umd.edu/access#Hidden'
+
+@pytest.mark.parametrize(
+    ('rdf_types', 'is_published', 'is_top_level', 'is_hidden', 'is_discoverable'),
+    [
+        # Published, but not top-level or hidden
+        ([published_type], True, False, False, False),
+        # Top level, but not published or hidden
+        ([top_level_type], False, True, False, False),
+        # Published and top-level, but not hidden, so discoverable
+        ([published_type, top_level_type], True, True, False, True),
+        # Published, top-level, and hidden, so not discoverable
+        ([published_type, top_level_type, hidden_type], True, True, True, False),
+    ]
+)
+def test_remove_hdl_prefix(index, rdf_types, is_published, is_top_level, is_hidden, is_discoverable):
+    doc = index({'rdf_type': rdf_types})
+    assert doc['is_published'] == is_published
+    assert doc['is_top_level'] == is_top_level
+    assert doc['is_hidden'] == is_hidden
+    assert doc['is_discoverable'] == is_discoverable


### PR DESCRIPTION
- Added fields to schema.
- Added logic to index helper to set the new fields appropriately.
- Added tests to verify fields are set correctly.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1254