### PR TITLE
LIBFCREPO-1288. Added "presentation_set_label" field as "docValue"

### DIFF
--- a/fedora4/core/conf/schema.xml
+++ b/fedora4/core/conf/schema.xml
@@ -105,6 +105,7 @@
   <field name="collection_title_facet" type="string" indexed="true" stored="true" multiValued="true"/>
   <field name="publication_status" type="string" indexed="true" stored="true" multiValued="false"/>
   <field name="visibility" type="string" indexed="true" stored="true" multiValued="false"/>
+  <field name="presentation_set_label" type="string" indexed="false" stored="false" multiValued="true" docValues="true" useDocValuesAsStored="true"/>
 
   <!-- Annotation Fields -->
   <field name="annotation_source" type="string" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
Added "presentation_set_label" field as a "docValue" to the "Facets Fields" list. As a "docValue", the "sorted" and "indexed" fields can be set to "false".

The "useDocValuesAsStored" is set to "true" because that is the default in Solr schema 1.6 (we are currently using Solr schema v1.5), so that the field value will be returned in Solr "fl" wildcard queries.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1288