### PR TITLE
LIBFCREPO-1353. Only populate publication and discoverability fields for top-level objects.

### DIFF
--- a/fedora4/core/conf/index-helper.js
+++ b/fedora4/core/conf/index-helper.js
@@ -405,13 +405,15 @@ function setPublicationAndDiscoveryStatusFields(doc) {
       is_top_level = true;
     }
   }
-  doc.setField(SOLR_IS_PUBLISHED, is_published);
-  doc.setField(SOLR_IS_HIDDEN, is_hidden);
   doc.setField(SOLR_IS_TOP_LEVEL, is_top_level);
-  // facet fields
-  doc.setField(SOLR_PUBLICATION_STATUS, publication_status);
-  doc.setField(SOLR_VISIBILITY, visibility);
+  if (is_top_level) {
+    doc.setField(SOLR_IS_PUBLISHED, is_published);
+    doc.setField(SOLR_IS_HIDDEN, is_hidden);
+    // facet fields
+    doc.setField(SOLR_PUBLICATION_STATUS, publication_status);
+    doc.setField(SOLR_VISIBILITY, visibility);
 
-  var is_discoverable = is_top_level && is_published && !is_hidden;
-  doc.setField(SOLR_IS_DISCOVERABLE, is_discoverable);
+    var is_discoverable = is_top_level && is_published && !is_hidden;
+    doc.setField(SOLR_IS_DISCOVERABLE, is_discoverable);
+  }
 }

--- a/tests/test_publish_and_discovery.py
+++ b/tests/test_publish_and_discovery.py
@@ -24,10 +24,10 @@ def test_publish_and_discovery_flags(index, rdf_types, is_published, is_top_leve
 
 
 def test_only_top_level_have_flags(index):
-    # Not top-level, should not have the "is_*" flags
+    # Not top-level, should not have the "is_*" flags other than "is_top_level:false"
     doc = index({})
+    assert not doc['is_top_level']
     assert 'is_published' not in doc
-    assert 'is_top_level' not in doc
     assert 'is_hidden' not in doc
     assert 'is_discoverable' not in doc
 

--- a/tests/test_publish_and_discovery.py
+++ b/tests/test_publish_and_discovery.py
@@ -7,8 +7,6 @@ hidden_type = 'http://vocab.lib.umd.edu/access#Hidden'
 @pytest.mark.parametrize(
     ('rdf_types', 'is_published', 'is_top_level', 'is_hidden', 'is_discoverable'),
     [
-        # Published, but not top-level or hidden
-        ([published_type], True, False, False, False),
         # Top level, but not published or hidden
         ([top_level_type], False, True, False, False),
         # Published and top-level, but not hidden, so discoverable
@@ -25,13 +23,22 @@ def test_publish_and_discovery_flags(index, rdf_types, is_published, is_top_leve
     assert doc['is_discoverable'] == is_discoverable
 
 
+def test_only_top_level_have_flags(index):
+    # Not top-level, should not have the "is_*" flags
+    doc = index({})
+    assert 'is_published' not in doc
+    assert 'is_top_level' not in doc
+    assert 'is_hidden' not in doc
+    assert 'is_discoverable' not in doc
+
+
 @pytest.mark.parametrize(
     ('rdf_types', 'publication_status', 'visibility'),
     [
-        ([], 'Unpublished', 'Visible'),
-        ([published_type], 'Published', 'Visible'),
-        ([hidden_type], 'Unpublished', 'Hidden'),
-        ([published_type, hidden_type], 'Published', 'Hidden'),
+        ([top_level_type], 'Unpublished', 'Visible'),
+        ([top_level_type, published_type], 'Published', 'Visible'),
+        ([top_level_type, hidden_type], 'Unpublished', 'Hidden'),
+        ([top_level_type, published_type, hidden_type], 'Published', 'Hidden'),
     ]
 )
 def test_publish_and_discovery_facets(index, rdf_types, publication_status, visibility):


### PR DESCRIPTION
https://umd-dit.atlassian.net/browse/LIBFCREPO-1353