### PR TITLE
LIBFCREPO-1341. Add "terms_of_use" field to Solr

### DIFF
--- a/fedora4/core/conf/schema.xml
+++ b/fedora4/core/conf/schema.xml
@@ -38,6 +38,7 @@
   <field name="genre" type="string" indexed="true" stored="true" multiValued="true"/>
   <field name="subject" type="string" indexed="true" stored="true" multiValued="true"/>
   <field name="rights" type="string" indexed="true" stored="true" multiValued="true"/>
+  <field name="terms_of_use_text" type="text_general" indexed="true" stored="true" multiValued="false"/>
   <field name="copyright_notice" type="text_general" indexed="true" stored="true" multiValued="false"/>
   <field name="collection" type="string" indexed="true" stored="true" multiValued="true"/>
   <field name="citation" type="text_general" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
Added the "terms_of_use" field to the Solr schema:

* Name: `terms_of_use_text`
* type: `text_general`
* indexed: `true`
* stored: `true`
* multiValue: `false`

https://umd-dit.atlassian.net/browse/LIBFCREPO-1341