### PR TITLE
LIBFCREPO-1499. Added "*__sequence" dynamic field definition.

### DIFF
--- a/fcrepo/core/conf/managed-schema.xml
+++ b/fcrepo/core/conf/managed-schema.xml
@@ -522,4 +522,5 @@
   <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
 
   <dynamicField name="is_*" type="boolean" indexed="true" stored="true"/>
+  <dynamicField name="*__sequence" type="strings" indexed="true" stored="true"/>
 </schema>


### PR DESCRIPTION
Stores lists of strings; used by the page_sequence and iiif_links Solrizer indexers.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1499