### PR TITLE
LIBFCREPO-1771. Added dynamic "*__time" and "*__times" fields

### DIFF
--- a/fcrepo/core/conf/managed-schema.xml
+++ b/fcrepo/core/conf/managed-schema.xml
@@ -489,6 +489,8 @@
   <dynamicField name="*__int" type="plong" indexed="true" stored="true"/>
   <dynamicField name="*__ints" type="plongs" indexed="true" stored="true"/>
   <dynamicField name="*__str" type="string" indexed="true" stored="true"/>
+  <dynamicField name="*__time" type="pdate" indexed="true" stored="true"/>
+  <dynamicField name="*__times" type="pdates" indexed="true" stored="true"/>
   <dynamicField name="*__txt" type="text_general" multiValued="false" indexed="true" stored="true"/>
   <dynamicField name="*__txts" type="text_general" indexed="true" stored="true"/>
   <dynamicField name="*__uri" type="string" indexed="true" stored="true"/>


### PR DESCRIPTION
Added dynamic "*__time" field (for single value) and "*__times" field
(for multivalue) that store "xsd:dateTime" data type fields via
Solrizer (see LIBFCREPO-1772).

* Name: `*__time`
* Type: `pdate`
* Indexed: True
* Stored: True

* Name: `*__times`
* Type: `pdates`
* Indexed: True
* Stored: True

https://umd-dit.atlassian.net/browse/LIBFCREPO-1771