### PR TITLE
LIBFCREPO-1780. Added a `last_indexed` field.

### DIFF
--- a/fcrepo/core/conf/managed-schema.xml
+++ b/fcrepo/core/conf/managed-schema.xml
@@ -476,6 +476,7 @@
   <field name="_text_" type="text_general" multiValued="true" indexed="true" stored="false"/>
   <field name="_version_" type="plong" indexed="false" stored="false"/>
   <field name="id" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
+  <field name="last_indexed" type="pdate" default="NOW" indexed="true" stored="true"/>
 
   <!-- data-typed fields -->
   <dynamicField name="*__curie" type="string" indexed="true" stored="true"/>


### PR DESCRIPTION
- automatically populated with the current timestamp whenever the Solr record is written
- named without the type suffix so it is not confused with the fields that are automatically named and typed base don the content model

https://umd-dit.atlassian.net/browse/LIBFCREPO-1780